### PR TITLE
Integrated Global Viewer in family-visualizations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Apertium-Global-PairViewer"]
+	path = Apertium-Global-PairViewer
+	url = https://github.com/jonorthwash/Apertium-Global-PairViewer

--- a/familymap.html
+++ b/familymap.html
@@ -378,7 +378,7 @@
                         1: function () { return drawContributionsDonut(langInfoBox, diameter * 5 / 6, diameter * 3 / 4, 10, 130, "1.5em", "1.5em", "1.17em", true, true); },
                         2: function () { return drawPairGraph(langInfoBox, diameter * 5 / 6, diameter * 3 / 4, "1.75em", [25, 70], [10, 35], true); },
                         3: function () { return drawDevelopmentPlot(langInfoBox, diameter * 5 / 6, diameter * 3 / 4, {top: 20, right: 50, bottom: 60, left: 70}, 5, 6, "2em", "1em", 40, 80, true, true, true); },
-                        4: function () { alert("Coming soon!"); }
+                        4: function () { return drawGlobeViewer(langInfoBox, diameter * 5 / 6, diameter * 7 / 10); }
                     };
 
                     function drawChartPreviews() {
@@ -408,6 +408,7 @@
                         drawContributionsDonut(d3.select(chartPreviews[0][0]), width - 15, height - 15, 10, 65, "1em", ".9em", ".85em");
                         drawPairGraph(d3.select(chartPreviews[0][1]), width - 15, height - 15, "1em", [5, 30], [5, 15]);
                         drawDevelopmentPlot(d3.select(chartPreviews[0][2]), width - 15, height - 15, {top: 30, right: 40, bottom: 40, left: 60}, 3, 5, "1.5em", ".6em", 150, 40);
+                        drawGlobeViewer(d3.select(chartPreviews[0][3]), width - 15, height - 15)
 
                         return chartPreviews;
                     }
@@ -955,6 +956,24 @@
                                 .style("opacity", 1);
 
                         return container.select("svg");
+                    }
+
+                    function drawGlobeViewer(container, width, height) {
+
+                        var globeView = container.append("object")
+                            .attr("width", width)
+                            .attr("height", height)
+                            .attr("data", "Apertium-Global-PairViewer/")
+                            .style("opacity", 1);
+
+
+                        globeView.on("load", function(){
+                          setTimeout(function(){
+                            globeView[0][0].contentWindow.filterPoint(langData.lang);
+                          }, 0);
+                        })
+
+                        return globeView;
                     }
                 });
 

--- a/familymap.html
+++ b/familymap.html
@@ -963,7 +963,7 @@
                         var globeView = container.append("object")
                             .attr("width", width)
                             .attr("height", height)
-                            .attr("data", "Apertium-Global-PairViewer/")
+                            .attr("data", "Apertium-Global-PairViewer/index.html")
                             .style("opacity", 1);
 
 


### PR DESCRIPTION
The fourth cell in family-visualizations now includes the global pairviewer. It's integrated as a git sub module to keep updated with changes to the Global Pairviewer.

This also filters the arcs to only display the ones connected to the language that has been clicked on, and automatically centers to the point with that language.

For [this issue](https://github.com/jonorthwash/Apertium-Global-PairViewer/issues/32), which seems to be in the wrong repository

Screenshots below:

![Screenshot (2)](https://user-images.githubusercontent.com/26374538/70354982-5387c800-1871-11ea-8864-bdcbfc6322df.PNG)
![Screenshot](https://user-images.githubusercontent.com/26374538/70354983-54205e80-1871-11ea-89f4-c323f67896ec.PNG)

